### PR TITLE
Convert the action type from docker to composite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM alpine:latest
-
-ADD sphinx_matcher.json /
-
-ENTRYPOINT ["/bin/sh", "-c", \
-    "cp /sphinx_matcher.json . && echo '::add-matcher::sphinx_matcher.json'"]

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,6 @@ branding:
 runs:
   using: composite
   steps:
-  - name: ✨ Activate the Sphinx Problem Matcher
+  - name: Activate the problem matcher
     run: echo '::add-matcher::${{ github.action_path }}/sphinx_matcher.json'
-    shell: bash
+    shell: sh

--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,8 @@ branding:
   icon: book
   color: yellow
 runs:
-  using: docker
-  image: Dockerfile
+  using: composite
+  steps:
+  - name: ✨ Activate the Sphinx Problem Matcher
+    run: echo '::add-matcher::${{ github.action_path }}/sphinx_matcher.json'
+    shell: bash


### PR DESCRIPTION
Previously, this action was using Docker containers as its runtime. It has a number of drawbacks, namely:

  * each workflow using the action, wastes resources building a fresh container from the `Dockerfile`;

  * `docker` actions only work on GNU/Linux runners and wouldn't be usable by the end-users running it as a part of a job matrix.

This patch converts the only meaningful configuration step to use a `composite` action interface, which is not as resource-hungry and runner-agnostic.

Resolves #3